### PR TITLE
test: add unit and integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^7.0.0",
@@ -22,6 +23,8 @@
     "postcss": "^8.4.21",
     "tailwindcss": "^3.3.2",
     "typescript": "^5.2.2",
-    "vite": "^5.0.0"
+    "vite": "^5.0.0",
+    "vitest": "^1.0.0",
+    "jsdom": "^24.0.0"
   }
 }

--- a/tests/animationMapper.test.ts
+++ b/tests/animationMapper.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getAnimationClassName,
+  getAvailableAnimations,
+  isValidAnimation,
+  generateAnimationCSS,
+} from '../src/utils/animationMapper';
+
+describe('animationMapper utilities', () => {
+  it('returns the correct class name for a known animation', () => {
+    expect(getAnimationClassName('Fade In')).toBe('fade-in');
+  });
+
+  it('validates whether an animation exists', () => {
+    expect(isValidAnimation('Fade In')).toBe(true);
+    expect(isValidAnimation('Unknown Animation')).toBe(false);
+  });
+
+  it('lists available entrance animations', () => {
+    const entranceAnimations = getAvailableAnimations('entrance');
+    expect(entranceAnimations).toContain('Fade In');
+    expect(entranceAnimations).not.toContain('Fade Out');
+  });
+
+  it('generates CSS containing keyframes and utility classes', () => {
+    const css = generateAnimationCSS();
+    expect(css).toContain('@keyframes fade-in-keyframes');
+    expect(css).toContain('.fade-in');
+  });
+});

--- a/tests/export.integration.test.ts
+++ b/tests/export.integration.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { SliderExporter, ExportOptions } from '../src/utils/export';
+import type { SliderProject } from '../src/types';
+
+const project: SliderProject = {
+  id: 'proj1',
+  name: 'Sample Project',
+  slides: [
+    {
+      id: 'slide1',
+      name: 'Slide 1',
+      background: { type: 'color', value: '#000000' },
+      duration: 5000,
+      layers: [
+        {
+          id: 'layer1',
+          type: 'text',
+          content: 'Hello World',
+          style: {
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 50,
+            opacity: 1,
+            rotation: 0,
+            zIndex: 1,
+          },
+          animation: {
+            entrance: 'Fade In',
+            exit: 'Fade Out',
+            duration: 1000,
+            delay: 0,
+            easing: 'ease',
+          },
+        },
+      ],
+    },
+  ],
+  settings: {
+    autoplay: true,
+    loop: true,
+    navigation: true,
+    pagination: true,
+    transitionType: 'fade',
+    transitionDuration: 1000,
+  },
+};
+
+const options: ExportOptions = {
+  format: 'html',
+  includeAnimations: true,
+  includeStyles: true,
+  autoplay: true,
+  loop: true,
+};
+
+describe('SliderExporter integration', () => {
+  it('generates full HTML document with CSS and JS', () => {
+    const output = SliderExporter.exportToHTML(project, options);
+    expect(output).toContain('<!DOCTYPE html>');
+    expect(output).toContain('.slider-container');
+    expect(output).toContain('class SliderRevolution');
+    expect(output).toContain('.fade-in {');
+  });
+
+  it('omits animation CSS when includeAnimations is false', () => {
+    const css = SliderExporter.generateCSS(project, { ...options, includeAnimations: false });
+    expect(css).not.toContain('.fade-in {');
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,10 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
 });


### PR DESCRIPTION
## Summary
- configure Vitest with jsdom environment
- add unit tests for animation mapping utilities
- add integration tests for HTML export

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689180d45bb0832bbca9860c03979803