### PR TITLE
feat: add shift modifier for snap-to-grid

### DIFF
--- a/src/hooks/useCanvasKeyboardShortcuts.ts
+++ b/src/hooks/useCanvasKeyboardShortcuts.ts
@@ -29,12 +29,10 @@ export function useCanvasKeyboardShortcuts({
             break;
           case ';':
             e.preventDefault();
-            onToggleGuides();
-            break;
-          case 'Shift':
             if (e.shiftKey) {
-              e.preventDefault();
               onToggleSnapToGrid();
+            } else {
+              onToggleGuides();
             }
             break;
         }


### PR DESCRIPTION
## Summary
- allow Ctrl+Shift+; to toggle snap-to-grid while Ctrl+; toggles guides

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689186538a10832bab4a2f6dae944b77